### PR TITLE
Avoid crashing on non instrumented responses

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PlugServerTiming.MixProject do
   def project do
     [
       app: :plug_server_timing,
-      version: "0.0.2",
+      version: "0.0.3",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/plug_server_timing_test.exs
+++ b/test/plug_server_timing_test.exs
@@ -1,4 +1,31 @@
 defmodule PlugServerTimingTest do
   use ExUnit.Case, async: true
   doctest PlugServerTiming
+  import PlugServerTiming.Plug, only: [generate_metrics_header: 1]
+
+  @instrumented_payload %{
+    metrics: [
+      %{
+        call_count: 1,
+        key: %{bucket: "chicken-wings", desc: nil, extra: nil, name: "all", scope: %{}},
+        max_call_time: 6.0e-6,
+        min_call_time: 6.0e-6,
+        sum_of_squares: 0,
+        total_call_time: 6.0e-6,
+        total_exclusive_time: 6.0e-6
+      }
+    ],
+    total_call_time: 6.0e-6
+  }
+
+  describe "#generate_metrics_header/1" do
+    test "with instrumented response" do
+      header = generate_metrics_header(@instrumented_payload)
+      assert header == "chicken-wings;dur=0.006,total;dur=0.006"
+    end
+
+    test "with an non instrumented response" do
+      assert generate_metrics_header(nil) == ""
+    end
+  end
 end


### PR DESCRIPTION
When i used 
```Elixir
def index(conn, _params)
  json(conn, %{})
end
```

In a controller action, total_call_time was missing from payload, causing a crash. It's better to skip instrumentation in this case than to fail the response.